### PR TITLE
Use GATK4 integrated Picard

### DIFF
--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -23,10 +23,6 @@ RUN apt-get update --fix-missing -qq && apt-get install -y -q \
 RUN curl -fjksSL --header "Cookie: oraclelicense=accept-securebackup-cookie" -L http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jre-8u121-linux-x64.tar.gz | tar xz && \
     update-alternatives --install /usr/bin/java java /jre1.8.0_121/bin/java 100
 
-# install Picard Tools
-RUN curl -fksSL https://github.com/broadinstitute/picard/releases/download/2.9.0/picard.jar > /usr/local/bin/picard.jar && \
-    chmod +x /usr/local/bin/picard.jar
-
 # install SAMtools
 RUN curl -fksSL https://github.com/samtools/samtools/releases/download/1.3.1/samtools-1.3.1.tar.bz2 | tar xj && \
     cd samtools-1.3.1 && \

--- a/main.nf
+++ b/main.nf
@@ -89,8 +89,7 @@ process '1B_prepare_genome_picard' {
 
   script:
   """
-  PICARD=`which picard.jar`
-  java -jar \$PICARD CreateSequenceDictionary R= $genome O= ${genome.baseName}.dict
+  gatk CreateSequenceDictionary -R $genome -O ${genome.baseName}.dict
   """
 }
 


### PR DESCRIPTION
Edited and tested `main.nf` to use Picard tools packaged within GATK4.

Modified `Dockerfile-base` to no longer package a separate Picard jar, NOT TESTED.