### PR TITLE
Use option instead of genome regeneration in STAR for 2-pass mapping

### DIFF
--- a/modules.nf
+++ b/modules.nf
@@ -119,18 +119,9 @@ process RNASEQ_MAPPING_STAR {
        --alignSJoverhangMin 8 \
        --alignSJDBoverhangMin 1 \
        --outFilterMismatchNmax 999
-    
-  # 2nd pass (improve alignmets using table of splice junctions and create a new index)  
-  mkdir genomeDir  
-  STAR --runMode genomeGenerate \
-       --genomeDir genomeDir \
-       --genomeFastaFiles $genome \
-       --sjdbFileChrStartEnd SJ.out.tab \
-       --sjdbOverhang 75 \
-       --runThreadN $task.cpus
-    
-  # Final read alignments  
-  STAR --genomeDir genomeDir \
+
+  # Run 2-pass mapping (improve alignmets using table of splice junctions and create a new index)  
+  STAR --genomeDir $genomeDir \
        --readFilesIn $reads \
        --runThreadN $task.cpus \
        --readFilesCommand zcat \
@@ -138,6 +129,7 @@ process RNASEQ_MAPPING_STAR {
        --alignSJoverhangMin 8 \
        --alignSJDBoverhangMin 1 \
        --outFilterMismatchNmax 999 \
+       --sjdbFileChrStartEnd SJ.out.tab \
        --outSAMtype BAM SortedByCoordinate \
        --outSAMattrRGline ID:$replicateId LB:library PL:illumina PU:machine SM:GM12878
 


### PR DESCRIPTION
Hi CalliNGS-NF developers and @lucacozzuto .

This pull request is to try to fix #26. If you change the method to the one recommended in the Star manual, you will be able to reduce the execution time.
The output files were compared before and after the change.

|file|Is it the same before and after the change?|
|---|---|
| `final.vcf`                                       | identical except for the timestamp. |
| `commonSNPs.diff.sites_in_files` | identical. |
| `known_snps.vcf.gz`                     | identical except for the timestamp. |
| `ASE.tsv`                                      | identical. |
| `AF.histogram.pdf`                        | has a binary difference, but the output looks identical. |
| `known_snps.vcf.gz.tbi`                | has a binary difference. |

I am not sure if such a simple change of options is enough.  This is just a suggestion.
I would appreciate it if you could review it. 

Thank you.